### PR TITLE
report error when a start tag is improperly closed

### DIFF
--- a/src/main/java/net/sourceforge/htmlunit/cyberneko/HTMLScanner.java
+++ b/src/main/java/net/sourceforge/htmlunit/cyberneko/HTMLScanner.java
@@ -2947,6 +2947,9 @@ public class HTMLScanner
             }
             else if (c == '<') {
                 fCurrentEntity.rewind();
+                if(fReportErrors) {
+                    fErrorReporter.reportError("HTML1016", null);
+                }
                 return false;
             }
             fCurrentEntity.rewind();

--- a/src/main/resources/net/sourceforge/htmlunit/cyberneko/res/ErrorMessages.properties
+++ b/src/main/resources/net/sourceforge/htmlunit/cyberneko/res/ErrorMessages.properties
@@ -25,6 +25,7 @@ HTML1014=Missing root element name in DOCTYPE.
 HTML1015=\
     Specified encoding "{0}" is not compatible with auto-detected encoding \
     "{1}". Ignoring charset directive.
+HTML1016=Error parsing attribute name.
 
 # tag balancer messages
 HTML2000=Empty document.

--- a/src/test/resources/error-handling/test-improperly-closed-tag.html
+++ b/src/test/resources/error-handling/test-improperly-closed-tag.html
@@ -1,0 +1,1 @@
+<html><body><div><span </span></div></body></html>

--- a/src/test/resources/error-handling/test-improperly-closed-tag.html.canonical
+++ b/src/test/resources/error-handling/test-improperly-closed-tag.html.canonical
@@ -1,0 +1,13 @@
+[Warn] HTML1000 No character encoding indicator at beginning of document.
+(html
+(head
+)head
+(body
+(div
+[Err] HTML1016 Error parsing attribute name.
+(span
+)span
+)div
+"\n
+)body
+)html

--- a/src/test/resources/error-handling/test-improperly-closed-tag.html.settings
+++ b/src/test/resources/error-handling/test-improperly-closed-tag.html.settings
@@ -1,0 +1,2 @@
+property http://cyberneko.org/html/properties/default-encoding ASCII 	
+feature http://cyberneko.org/html/features/report-errors true 	


### PR DESCRIPTION
Report an error when the scanner (in `scanAttribute`) finds the start of the next tag (implicitly closing the open start tag).

For example, markup like this:

```html
<html><body><div </div></body></html>
```

should report an error and currently does not. This change will report an error upon seeing the `<` while scanning for attributes on the starting `div` tag.

This behavior brings this parser's behavior in line with other HTML parsers including libxml2's HTML4 parser and libgumbo's HTML5 parser.

The relevant section of the WHATWG spec is https://html.spec.whatwg.org/multipage/parsing.html#before-attribute-name-state