### PR TITLE
StandardEncodingTranslator: Fix lacking IANA encoding to Java charset name conversion

### DIFF
--- a/src/main/java/org/htmlunit/cyberneko/xerces/util/StandardEncodingTranslator.java
+++ b/src/main/java/org/htmlunit/cyberneko/xerces/util/StandardEncodingTranslator.java
@@ -364,6 +364,35 @@ public final class StandardEncodingTranslator implements EncodingTranslator {
         ENCODING_FROM_LABEL.put("x-user-defined", "x-user-defined");
     }
 
+    /** <a href="https://docs.rs/encoding_rs/latest/encoding_rs/#notable-differences-from-iana-naming">Differences from iana naming</a> */
+    private static final Map<String, String> ENCODING_TO_IANA_ENCODING;
+
+    static {
+        ENCODING_TO_IANA_ENCODING = new HashMap<>();
+
+        /*
+         * Some WHATWG encodings are not the same as IANA encodings of the same names so names need to
+         * be converted for compatibility.
+         *
+         * For example, the WHATWG encoding of "shift_jis" has mappings of IANA's "windows-31j"
+         * (https://encoding.spec.whatwg.org/shift_jis.html) rather than the IANA's "shift_jis"
+         * (JIS X 0208).
+         *
+         * This distinction is vague and hard to find official information but is actually noted in
+         * Wikipedia: "This has led the WHATWG HTML standard to treat the encoding labels shift_jis and
+         * windows-31j interchangeably, and use the Windows variant for its "Shift_JIS" encoder and
+         * decoder." -- https://en.wikipedia.org/wiki/Code_page_932_(Microsoft_Windows)
+         *
+         * The same page references "Notable Differences from IANA Naming"
+         * (https://docs.rs/encoding_rs/latest/encoding_rs/#notable-differences-from-iana-naming)
+         * which has other candidates so that is the initial source of the entries in this list.
+         */
+        ENCODING_TO_IANA_ENCODING.put("big5", "big5-hkscs");
+        ENCODING_TO_IANA_ENCODING.put("euc-kr", "windows-949");
+        ENCODING_TO_IANA_ENCODING.put("shift_jis", "windows-31j");
+        ENCODING_TO_IANA_ENCODING.put("x-mac-cyrillic", "x-mac-ukrainian");
+    }
+
     private StandardEncodingTranslator() {
     }
 
@@ -379,6 +408,8 @@ public final class StandardEncodingTranslator implements EncodingTranslator {
         }
         String label = charsetLabel.trim().toLowerCase(Locale.ROOT);
         String ianaEncoding = ENCODING_FROM_LABEL.get(label);
+        // Convert WHATWG names to IANA names
+        ianaEncoding = ENCODING_TO_IANA_ENCODING.getOrDefault(ianaEncoding, ianaEncoding);
         // Convert our IANA encoding names to Java charset names
         return EncodingMap.INSTANCE.encodingNameFromLabel(ianaEncoding);
     }

--- a/src/main/java/org/htmlunit/cyberneko/xerces/util/StandardEncodingTranslator.java
+++ b/src/main/java/org/htmlunit/cyberneko/xerces/util/StandardEncodingTranslator.java
@@ -378,6 +378,8 @@ public final class StandardEncodingTranslator implements EncodingTranslator {
             return null;
         }
         String label = charsetLabel.trim().toLowerCase(Locale.ROOT);
-        return ENCODING_FROM_LABEL.get(label);
+        String ianaEncoding = ENCODING_FROM_LABEL.get(label);
+        // Convert our IANA encoding names to Java charset names
+        return EncodingMap.INSTANCE.encodingNameFromLabel(ianaEncoding);
     }
 }


### PR DESCRIPTION
### This PR does the following

We suspect commit 68eed13a4bd8e034f3fcda062ee37bc18854a21f is maybe incorrectly placing `StandardEncodingTranslator.ENCODING_FROM_LABEL` and `EncodingMap.fIANA2JavaMap` as interchangeable mappings when in fact they are different concepts and both mappings are needed to produce Java charset names. This PR attempts to rectify this like so:
1. Labels are converted to WHATWG encoding names (mostly IANA encoding names)
    * Uses `StandardEncodingTranslator.ENCODING_FROM_LABEL`
2. IANA encoding names are converted to Java charset names
    * Uses `EncodingMap.getIANA2JavaMapping()` (reintroduced in this PR)

Moreover, some WHATWG encoding names are not actually IANA names and this PR adds another intermediate conversion to produce IANA names:
1. Labels are converted to WHATWG encoding names
    * Uses `StandardEncodingTranslator.ENCODING_FROM_LABEL`
2. WHATWG encoding names are converted to IANA names
    * Uses `StandardEncodingTranslator.ENCODING_TO_IANA_ENCODING` (added in this PR)
2. IANA encoding names are converted to Java charset names
    * Uses `EncodingMap.getIANA2JavaMapping()`

### Testing

We used `sjis_comparison.html` from [test_files.zip](https://github.com/HtmlUnit/htmlunit-neko/files/15008347/test_files.zip) to confirm "shift_jis" is indeed treated as "windows-31j" in normal browsers.

We then used `test.html` to test in HtmlUnit. It's expected to produce:
* Expected: `―～∥－￠￡￢` (windows-31j decoded)
* Incorrect: `—〜‖−¢£¬` (JIS X 0208 decoded).

The two lines may or may not look identical depending on OS, language and font settings. The two however have completely different codepoints.