### PR TITLE
StandardEncodingTranslator: Fix big5, euc-kr, koi8-u, etc regressions

### DIFF
--- a/src/main/java/org/htmlunit/cyberneko/HTMLScanner.java
+++ b/src/main/java/org/htmlunit/cyberneko/HTMLScanner.java
@@ -24,6 +24,7 @@ import java.io.Reader;
 import java.io.StringReader;
 import java.io.UnsupportedEncodingException;
 import java.net.URL;
+import java.nio.charset.Charset;
 import java.util.Locale;
 
 import org.htmlunit.cyberneko.io.PlaybackInputStream;
@@ -821,7 +822,7 @@ public class HTMLScanner implements XMLDocumentScanner, XMLLocator, HTMLComponen
             }
             if (encodings[1] == null) {
                 encodings[1] = fEncodingTranslator.encodingNameFromLabel(encodings[0]);
-                if (encodings[1] == null) {
+                if (encodings[1] == null || !Charset.isSupported(encodings[1])) {
                     encodings[1] = encodings[0];
                     if (fReportErrors_) {
                         fErrorReporter.reportWarning("HTML1001", new Object[] {encodings[0]});
@@ -3007,7 +3008,7 @@ public class HTMLScanner implements XMLDocumentScanner, XMLLocator, HTMLComponen
                     System.out.println("+++ ianaEncoding: " + charset);
                     System.out.println("+++ javaEncoding: " + javaEncoding);
                 }
-                if (javaEncoding == null) {
+                if (javaEncoding == null || (!Charset.isSupported(charset) && charset != StandardEncodingTranslator.REPLACEMENT)) {
                     javaEncoding = charset;
                     if (fReportErrors_) {
                         fErrorReporter.reportError("HTML1001", new Object[] {charset});

--- a/src/test/java/org/htmlunit/cyberneko/xerces/util/StandardEncodingTranslatorTest.java
+++ b/src/test/java/org/htmlunit/cyberneko/xerces/util/StandardEncodingTranslatorTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2024-2024 Atsushi Nakagawa
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.htmlunit.cyberneko.xerces.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.charset.Charset;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+
+import org.junit.jupiter.api.Test;
+
+public class StandardEncodingTranslatorTest {
+
+    @Test
+    public void conversions() throws Exception {
+        assertEquals("windows-1252", StandardEncodingTranslator.INSTANCE.encodingNameFromLabel("ascii"));
+        assertEquals("utf-8", StandardEncodingTranslator.INSTANCE.encodingNameFromLabel("utf-8"));
+        assertEquals("utf-8", StandardEncodingTranslator.INSTANCE.encodingNameFromLabel("utf8"));
+        assertEquals("windows-874", StandardEncodingTranslator.INSTANCE.encodingNameFromLabel("windows-874"));
+        assertEquals("koi8-u", StandardEncodingTranslator.INSTANCE.encodingNameFromLabel("koi8-u"));
+        assertEquals("big5-hkscs", StandardEncodingTranslator.INSTANCE.encodingNameFromLabel("big5"));
+        assertEquals("windows-949", StandardEncodingTranslator.INSTANCE.encodingNameFromLabel("euc-kr"));
+        assertEquals("windows-949", StandardEncodingTranslator.INSTANCE.encodingNameFromLabel("windows-949"));
+        assertEquals("windows-31j", StandardEncodingTranslator.INSTANCE.encodingNameFromLabel("shift_jis"));
+        assertEquals("windows-31j", StandardEncodingTranslator.INSTANCE.encodingNameFromLabel("sjis"));
+        assertEquals("windows-31j", StandardEncodingTranslator.INSTANCE.encodingNameFromLabel("windows-31j"));
+        assertEquals("iso-8859-8", StandardEncodingTranslator.INSTANCE.encodingNameFromLabel("iso-8859-8-i"));
+        assertEquals("utf-16le", StandardEncodingTranslator.INSTANCE.encodingNameFromLabel("utf-16le"));
+        assertEquals("utf-16be", StandardEncodingTranslator.INSTANCE.encodingNameFromLabel("utf-16be"));
+
+        assertEquals("x-MacRoman", StandardEncodingTranslator.INSTANCE.encodingNameFromLabel("macintosh"));
+        assertEquals("x-MacUkraine", StandardEncodingTranslator.INSTANCE.encodingNameFromLabel("x-mac-cyrillic"));
+        assertEquals("x-MacUkraine", StandardEncodingTranslator.INSTANCE.encodingNameFromLabel("x-mac-ukrainian"));
+
+        // These are defined but not supported by reference Java 8
+        // https://docs.oracle.com/javase/8/docs/technotes/guides/intl/encoding.doc.html
+        assertEquals("iso-8859-10", StandardEncodingTranslator.INSTANCE.encodingNameFromLabel("iso-8859-10"));
+        assertEquals("iso-8859-14", StandardEncodingTranslator.INSTANCE.encodingNameFromLabel("iso-8859-14"));
+        // This one is added in Java 10 (https://bugs.openjdk.org/browse/JDK-8186751)
+        assertEquals("iso-8859-16", StandardEncodingTranslator.INSTANCE.encodingNameFromLabel("iso-8859-16"));
+
+        // Special WHATWG definitions
+        assertEquals("replacement", StandardEncodingTranslator.INSTANCE.encodingNameFromLabel("replacement"));
+        assertEquals("x-user-defined", StandardEncodingTranslator.INSTANCE.encodingNameFromLabel("x-user-defined"));
+
+        assertEquals(null, StandardEncodingTranslator.INSTANCE.encodingNameFromLabel("foo"));
+    }
+
+    @Test
+    void unsupportedCharsets() throws Exception {
+        final Collection<String> unsupported = new LinkedHashSet<>();
+        for (String encoding : new LinkedHashSet<>(StandardEncodingTranslator.ENCODING_FROM_LABEL.values())) {
+            encoding = StandardEncodingTranslator.INSTANCE.encodingNameFromLabel(encoding);
+            if (!Charset.isSupported(encoding)) {
+                unsupported.add(encoding);
+            }
+        }
+        // Added in Java 10 (https://bugs.openjdk.org/browse/JDK-8186751)
+        unsupported.remove("iso-8859-16");
+
+        assertEquals("[iso-8859-14, iso-8859-10, replacement, x-user-defined]", unsupported.toString());
+    }
+}


### PR DESCRIPTION
# This PR does the following

This PR firstly attempts to fix regressions introduced in #110 by restoring these encodings:

| Encoding | Cause |
|-|-|
| windows-874 | Was not supported in `EncodingMap.fIANA2JavaMap` |
| koi8-u | Was not supported in `EncodingMap.fIANA2JavaMap` |
| big5 | Adjusted form `big5-hkscs` was not supported in `EncodingMap.fIANA2JavaMap` |
| euc-kr | Adjusted form `windows-949` was not supported in `EncodingMap.fIANA2JavaMap` |
| x-user-defined | Was not supported in `EncodingMap.fIANA2JavaMap` (obviously) |

To do this, this PR removes the troublesome dependency on `EncodingMap.fIANA2JavaMap` and internally defines `IANA_TO_JAVA_ENCODINGS`.

In doing so, this PR also adds support to these encodings and labels that were not previously supported.

| Encoding | Labels |
|-|-|
| macintosh | csmacintosh, mac, x-mac-roman |
| x-mac-cyrillic | x-mac-ukrainian |

Finally, this PR attempts to fix parts of `HTMLScanner` that will be confused by `StandardEncodingTranslator.encodingNameFromLabel()` returning a non-null value which is not a valid Java encoding. **

** With the exception of "replacement", see following heading.

# This PR does not do the following

The following appears to be an issue but I didn't attempt to fix this due to limited knowledge:

The word `"replacement"` can make its way[1] into `HTMLScanner.fJavaEncoding` even though this field seems to be used as a sanitised source[2]. I don't know how to fix this or what we want to do with "replacement" so I simply let it through[3] in this PR.

[1] https://github.com/HtmlUnit/htmlunit-neko/blob/76bb1d16575d02f443c037aa54ecc7395d91b7f2/src/main/java/org/htmlunit/cyberneko/HTMLScanner.java#L3019
[2] https://github.com/HtmlUnit/htmlunit-neko/blob/76bb1d16575d02f443c037aa54ecc7395d91b7f2/src/main/java/org/htmlunit/cyberneko/HTMLScanner.java#L528-L531
[3] https://github.com/HtmlUnit/htmlunit-neko/pull/111/files#diff-c0ef5d78bafd2e2d032b106fd0ca50086966f97030bd6b6f4403d8f5ebe39f87R3011