### PR TITLE
HTMLScanner.scanName: ASCII fast-path for the per-char inner loop

### DIFF
--- a/src/main/java/org/htmlunit/cyberneko/HTMLScanner.java
+++ b/src/main/java/org/htmlunit/cyberneko/HTMLScanner.java
@@ -1308,20 +1308,33 @@ public class HTMLScanner implements XMLDocumentSource, XMLLocator, HTMLComponent
             while (fCurrentEntity.hasNext()) {
                 final char c = fCurrentEntity.getNextChar();
 
-                // this has been split up to cater to the needs of branch prediction
-                if (strict && (!Character.isLetterOrDigit(c) && c != '-' && c != '.' && c != ':' && c != '_')) {
-                    fCurrentEntity.rewind();
-                    break;
+                // ASCII fast-paths first: HTML element/attribute names are virtually
+                // always lowercase ASCII letters and digits, and the JDK Character.*
+                // helpers are not inlineable. Falling through to them only for c >= 0x80.
+                if (strict) {
+                    final boolean isNameChar;
+                    if (c < 0x80) {
+                        isNameChar = (c >= 'a' && c <= 'z')
+                                  || (c >= 'A' && c <= 'Z')
+                                  || (c >= '0' && c <= '9')
+                                  || c == '-' || c == '.' || c == ':' || c == '_';
+                    }
+                    else {
+                        isNameChar = Character.isLetterOrDigit(c);
+                    }
+                    if (!isNameChar) {
+                        fCurrentEntity.rewind();
+                        break;
+                    }
                 }
                 // we check for the regular space first because isWhitespace is no inlineable and hence expensive
                 // regular space should be the norm as well as newlines
-                else if (!strict
-                            && (c == ' '
-                                    || c == '\n'
-                                    || c == '='
-                                    || c == '/'
-                                    || c == '>'
-                                    || Character.isWhitespace(c))) {
+                else if (c == ' '
+                            || c == '\n'
+                            || c == '='
+                            || c == '/'
+                            || c == '>'
+                            || Character.isWhitespace(c)) {
                     fCurrentEntity.rewind();
                     break;
                 }
@@ -1329,11 +1342,23 @@ public class HTMLScanner implements XMLDocumentSource, XMLLocator, HTMLComponent
                 if (NAMES_NO_CHANGE == mode) {
                     // nothing to do
                 }
-                else if (NAMES_UPPERCASE == mode && !Character.isUpperCase(c)) {
-                    fCurrentEntity.buffer_[fCurrentEntity.offset_ - 1] = Character.toUpperCase(c);
+                else if (NAMES_LOWERCASE == mode) {
+                    // ASCII fast-path: most names already arrive lowercase. Avoid
+                    // Character.isLowerCase + Character.toLowerCase round-trip for them.
+                    if (c >= 'A' && c <= 'Z') {
+                        fCurrentEntity.buffer_[fCurrentEntity.offset_ - 1] = (char) (c | 0x20);
+                    }
+                    else if (c >= 0x80 && !Character.isLowerCase(c)) {
+                        fCurrentEntity.buffer_[fCurrentEntity.offset_ - 1] = Character.toLowerCase(c);
+                    }
                 }
-                else if (NAMES_LOWERCASE == mode && !Character.isLowerCase(c)) {
-                    fCurrentEntity.buffer_[fCurrentEntity.offset_ - 1] = Character.toLowerCase(c);
+                else if (NAMES_UPPERCASE == mode) {
+                    if (c >= 'a' && c <= 'z') {
+                        fCurrentEntity.buffer_[fCurrentEntity.offset_ - 1] = (char) (c & 0x5F);
+                    }
+                    else if (c >= 0x80 && !Character.isUpperCase(c)) {
+                        fCurrentEntity.buffer_[fCurrentEntity.offset_ - 1] = Character.toUpperCase(c);
+                    }
                 }
             }
             if (fCurrentEntity.offset_ == fCurrentEntity.length_) {


### PR DESCRIPTION
`scanName` runs once per element and once per attribute name and is one of the hottest frames in a parser-only profile (~5% self-time on a typical HTML page). The inner loop calls `Character.isLetterOrDigit`, `Character.isLowerCase` / `isUpperCase`, and `Character.toLowerCase` / `toUpperCase` per character, none of which are JIT-inlineable -- the existing comment in the same method already hand-tunes the whitespace check around this exact concern.

HTML element/attribute names are virtually always lowercase ASCII, so:

- For the strict-mode "is name char?" check: explicit ASCII branch (a-z / A-Z / 0-9 / - . : _) before falling through to `Character.isLetterOrDigit` only for `c >= 0x80`.
- For `NAMES_LOWERCASE`: if `c` is uppercase ASCII, lowercase via `c | 0x20` (no JDK call); only `Character.toLowerCase` for non-ASCII chars that aren't already lowercase. Symmetric for `NAMES_UPPERCASE`.

Behavior is preserved for all inputs, including non-ASCII names that fall through to the JDK methods.

JMH HtmlUnitBenchmark.JMH on a ~30 KB HTML page (5 forks x 3 warmup x 5 measurement = 25 samples, paired sequentially in one JMH session on top of a corresponding htmlunit-side change that defers the HtmlPage id/name index build):

  before: 593.611 +- 13.110 us/op
  after:  564.642 +- 11.833 us/op
  delta:  -29.0 us, -4.9%

Tests: full htmlunit-neko suite (mvn -Dgpg.skip test) -- 8407 tests, 0 failures, 0 errors. CanonicalSAXTest / CanonicalTest / CanonicalDomFragmentTest (1156 cases each, the scanner-correctness suites) all pass.